### PR TITLE
memory leak fix for lu_calc_offs_free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ run:
 	bin/$(TARGET) 0 10000000000
 
 # Test the newest plan against the previous (working) plan
-test:
+test: bin/$(TARGET_DEBUG)
 	bin/$(TARGET_DEBUG) 0 1000000000 1 0
 
 clean:

--- a/src/calc_blocks/lu_calc_offs.c
+++ b/src/calc_blocks/lu_calc_offs.c
@@ -79,10 +79,13 @@ lu_calc_offs_free(void *ctx)
    struct lu_calc_offs_ctx *sctx = ctx;
    int i;
    int k;
-   for (k = 0; k < sctx->nthreads; k++)
+   for (k = 0; k < sctx->nthreads; k++) {
       for (i = 0; i < 8; i++)
          FREE(sctx->plist[k][i].primes);
-   /* TODO: more freeing */
+      FREE(sctx->plist[k]);
+   }
+
+   FREE(sctx->plist);
    FREE(ctx);
    return 0;
 }


### PR DESCRIPTION
Added some calls to free for additional data members in lu_calc_offs_free (and a trivial update to the Makefile for ease of testing). Fixes errors detected with -fsanitize=leak
