### PR TITLE
cleaning for -Wextra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DEBUG_PROG_MAIN = src/prog/test.c
 
 LDFLAGS = -lm -lrt -lpthread
 CC  = gcc-5
-CFLAGS = -D_ISOC11_SOURCE -Wall $(foreach var, $(HEADERDIRS), -I $(var))
+CFLAGS = -D_ISOC11_SOURCE -Wall -Wextra $(foreach var, $(HEADERDIRS), -I $(var))
 OPTIMISE =  -O3 -march=native
 OPTIMISE_DEBUG =  -march=native
 

--- a/src/calc_blocks/load_unaligned.c
+++ b/src/calc_blocks/load_unaligned.c
@@ -119,8 +119,12 @@ load_unaligned_add_sieving_primes(uint32_t *primelist, uint32_t *ind, uint32_t s
 
 
 int
-load_unaligned_skip_to(struct prime_thread_ctx *__attribute__((unused))pctx, uint64_t __attribute__((unused))target_num, void *__attribute__((unused))ctx)
+load_unaligned_skip_to(struct prime_thread_ctx *pctx, uint64_t target_num, void *ctx)
 {
+   (void)pctx;
+   (void)target_num;
+   (void)ctx;
+
    return 0;
 }
 

--- a/src/calc_blocks/read_offs.c
+++ b/src/calc_blocks/read_offs.c
@@ -76,8 +76,11 @@ read_offs_add_sieving_primes(uint32_t *primelist, uint32_t *ind, uint32_t size, 
 
 
 int
-read_offs_skip_to(struct prime_thread_ctx *__attribute__((unused))pctx, uint64_t __attribute__((unused))target_num, void *__attribute__((unused))ctx)
+read_offs_skip_to(struct prime_thread_ctx *pctx, uint64_t target_num, void *ctx)
 {
+   (void)pctx;
+   (void)target_num;
+
    struct read_offs_ctx *sctx = ctx;
 
    /* Recalculate all of the offsets depending on the new block */

--- a/src/calc_blocks/simple.c
+++ b/src/calc_blocks/simple.c
@@ -57,8 +57,12 @@ simple_add_sieving_primes(uint32_t *primelist, uint32_t *ind, uint32_t size, voi
 
 
 int
-simple_skip_to(struct prime_thread_ctx *__attribute__((unused))pctx, uint64_t __attribute__((unused))target_num, void *__attribute__((unused))ctx)
+simple_skip_to(struct prime_thread_ctx *pctx, uint64_t target_num, void *ctx)
 {
+   (void)pctx;
+   (void)target_num;
+   (void)ctx;
+
    return 0;
 }
 

--- a/src/calc_blocks/simple_middle.c
+++ b/src/calc_blocks/simple_middle.c
@@ -76,8 +76,11 @@ simple_middle_add_sieving_primes(uint32_t *primelist, uint32_t *ind, uint32_t si
 
 
 int
-simple_middle_skip_to(struct prime_thread_ctx *__attribute__((unused))pctx, uint64_t __attribute__((unused))target_num, void *__attribute__((unused))ctx)
+simple_middle_skip_to(struct prime_thread_ctx *pctx, uint64_t target_num, void *ctx)
 {
+   (void)pctx;
+   (void)target_num;
+
    struct simple_middle_ctx *sctx = ctx;
    /* Recalculate all of the offsets depending on the new block */
    sctx->calculated_index = 0;

--- a/src/calc_blocks/slow.c
+++ b/src/calc_blocks/slow.c
@@ -56,8 +56,12 @@ slow_add_sieving_primes(uint32_t *primelist, uint32_t *ind, uint32_t size, void 
 
 
 int
-slow_skip_to(struct prime_thread_ctx *__attribute__((unused))pctx, uint64_t __attribute__((unused))target_num, void *__attribute__((unused))ctx)
+slow_skip_to(struct prime_thread_ctx *pctx, uint64_t target_num, void *ctx)
 {
+   (void)pctx;
+   (void)target_num;
+   (void)ctx;
+
    return 0;
 }
 

--- a/src/common/ctx.c
+++ b/src/common/ctx.c
@@ -25,7 +25,7 @@ set_run_info(struct prime_run_info *rinfo, uint64_t start, uint64_t end, uint64_
 static void
 set_initial_block(struct prime_current_block *cb, uint32_t block_size)
 {
-   cb->block = aligned_alloc(32*1024, CEIL_TO(block_size + 64*1024 , 1024)) + 32*1024;
+   cb->block = (char*)aligned_alloc(32*1024, CEIL_TO(block_size + 64*1024 , 1024)) + 32*1024;
    cb->block_size = block_size;
    cb->block_start_num = 0;
    cb->block_end_num = bytes_to_num(block_size);

--- a/src/prime/prime.c
+++ b/src/prime/prime.c
@@ -139,8 +139,10 @@ get_next_block (struct prime_thread_ctx *ptx, struct prime_current_block *pcb)
 {
    struct prime_ctx *pm = ptx->main;
 
-   if (ptx->run_num--)
-      return get_next_block_single(pcb);
+   if (ptx->run_num--) {
+      get_next_block_single(pcb);
+      return;
+   }
 
    ptx->run_num = pm->blocks_per_run - 1;
 


### PR DESCRIPTION
I've cleaned the tree for silent building under Wextra. There were only three main issues:
- void pointer arithmetic fixed with a simple cast
- void function returning a value
- replacing attribute unused with void casts.

The latter could have been fixed by moving the attribute specifier after the variable name, but this way doesn't rely on compiler extensions and gives cleaner looking function headers.
